### PR TITLE
Fix hand iteration logic and dimension usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ while True:
     debug = True
     # Read each frame from the webcam
     _, frame = cap.read()
-    x, y, c = frame.shape
+    h, w, c = frame.shape
 
     frame = cv2.flip(frame, 1)
 
@@ -74,8 +74,8 @@ while True:
         real_coordinates = []
         for handslms in result.multi_hand_landmarks:
             for lm in handslms.landmark:
-                lmx = int(lm.x * x)
-                lmy = int(lm.y * y)
+                lmx = int(lm.x * w)
+                lmy = int(lm.y * h)
                 lmz = float(lm.z)
                 landmarks.append([lmx, lmy])
                 real_coordinates.append((lmx, lmy, lmz))

--- a/utils/Hand.py
+++ b/utils/Hand.py
@@ -11,6 +11,7 @@ class Hand():
         try:
             self.previous_actions = previous_actions
             self.details = details
+            # total number of hands detected based on landmark count
             self.hand = 2 if len(real_coordinates) > 21 else 1
 
             self.directions = {
@@ -28,11 +29,10 @@ class Hand():
             self.cache = {}
 
 
-            for item in range(0, len(real_coordinates), 42):
-                if self.hand == 1:
-                    coordinates = real_coordinates[:21]
-                else:
-                    coordinates = real_coordinates[21:]
+            for item in range(0, len(real_coordinates), 21):
+                # slice the landmarks for each detected hand
+                coordinates = real_coordinates[item:item + 21]
+                self.hand = item // 21 + 1
 
                 self.direction = self.calculate_direction(coordinates)
                 self.palm = self.calculate_palm(self.direction)
@@ -55,8 +55,13 @@ class Hand():
                 #     self.set_volume_percentage(valor)
 
 
-                if self.details.any():
-                    self.debug()
+                if self.details is not None:
+                    # ensure debug data is drawn only when a debug frame is provided
+                    if hasattr(self.details, "any"):
+                        if self.details.any():
+                            self.debug()
+                    else:
+                        self.debug()
 
                 self.hand += 1
         except Exception as e:


### PR DESCRIPTION
## Summary
- correctly retrieve frame dimensions as height and width
- iterate over detected hands with slices of 21 landmarks
- guard debug display when frame isn't provided

## Testing
- `python -m py_compile main.py utils/Hand.py`


------
https://chatgpt.com/codex/tasks/task_e_68530f10b238832a9f348488dad47797